### PR TITLE
Feature/mapping per version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "jakub-onderka/php-console-highlighter": "^0.3.2",
-        "ruflin/elastica": "^5.2",
+        "ruflin/elastica": "^6.0.1",
         "php-http/httplug": "^1.1.0",
         "monolog/monolog": "^1.21.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,33 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "edd245f0443beff50d2a218b9afaa22d",
+    "content-hash": "36b702ec8d3b0d80818a493393cd1fcb",
     "packages": [
         {
             "name": "elasticsearch/elasticsearch",
-            "version": "v5.3.0",
+            "version": "v6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elastic/elasticsearch-php.git",
-                "reference": "50e5b1c63db68839b8acc1f4766769570a27a448"
+                "reference": "b8e3bc9d1fc54d6a18692df0b74956efe7fe241a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/50e5b1c63db68839b8acc1f4766769570a27a448",
-                "reference": "50e5b1c63db68839b8acc1f4766769570a27a448",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/b8e3bc9d1fc54d6a18692df0b74956efe7fe241a",
+                "reference": "b8e3bc9d1fc54d6a18692df0b74956efe7fe241a",
                 "shasum": ""
             },
             "require": {
+                "ext-json": ">=1.3.7",
                 "guzzlehttp/ringphp": "~1.0",
-                "php": "^5.6|^7.0",
+                "php": "^7.0",
                 "psr/log": "~1.0"
             },
             "require-dev": {
                 "cpliakas/git-wrapper": "~1.0",
                 "doctrine/inflector": "^1.1",
                 "mockery/mockery": "0.9.4",
-                "phpunit/phpunit": "^4.7|^5.4",
-                "sami/sami": "~3.2",
+                "phpstan/phpstan-shim": "0.8.3",
+                "phpunit/phpunit": "6.3.0",
+                "squizlabs/php_codesniffer": "3.0.2",
                 "symfony/finder": "^2.8",
                 "symfony/yaml": "^2.8"
             },
@@ -59,7 +61,7 @@
                 "elasticsearch",
                 "search"
             ],
-            "time": "2017-07-19T18:44:30+00:00"
+            "time": "2017-12-05T14:15:58+00:00"
         },
         {
             "name": "guzzlehttp/ringphp",
@@ -625,21 +627,21 @@
         },
         {
             "name": "ruflin/elastica",
-            "version": "5.3.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ruflin/Elastica.git",
-                "reference": "6ca31124a7753edbe3cec0f7a0cb723829da57c5"
+                "reference": "0bd18985d5c6a2aaabfe23fda0b4839538b6f6d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/6ca31124a7753edbe3cec0f7a0cb723829da57c5",
-                "reference": "6ca31124a7753edbe3cec0f7a0cb723829da57c5",
+                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/0bd18985d5c6a2aaabfe23fda0b4839538b6f6d5",
+                "reference": "0bd18985d5c6a2aaabfe23fda0b4839538b6f6d5",
                 "shasum": ""
             },
             "require": {
-                "elasticsearch/elasticsearch": "5.3.0",
-                "php": ">=5.6.0",
+                "elasticsearch/elasticsearch": "6.0.*",
+                "php": "^7.0",
                 "psr/log": "~1.0"
             },
             "require-dev": {
@@ -655,7 +657,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2.x-dev"
+                    "dev-master": "6.0.x-dev"
                 }
             },
             "autoload": {
@@ -679,38 +681,38 @@
                 "client",
                 "search"
             ],
-            "time": "2017-07-26T12:21:58+00:00"
+            "time": "2018-02-18T21:12:53+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -735,7 +737,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -940,29 +942,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.1.1",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -981,7 +989,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-30T18:51:59+00:00"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1032,28 +1040,28 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.2",
+            "version": "1.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
             },
             "type": "library",
             "extra": {
@@ -1091,20 +1099,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-09-04T11:05:03+00:00"
+            "time": "2018-04-18T13:57:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.3",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d"
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
-                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
                 "shasum": ""
             },
             "require": {
@@ -1113,14 +1121,13 @@
                 "php": "^7.0",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0",
+                "phpunit/php-token-stream": "^2.0.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
                 "phpunit/phpunit": "^6.0"
             },
             "suggest": {
@@ -1129,7 +1136,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -1144,7 +1151,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1155,20 +1162,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-03T13:47:33+00:00"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -1202,7 +1209,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1296,16 +1303,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
@@ -1341,20 +1348,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-08-20T05:47:52+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.4.4",
+            "version": "6.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932"
+                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/562f7dc75d46510a4ed5d16189ae57fbe45a9932",
-                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
+                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
                 "shasum": ""
             },
             "require": {
@@ -1368,12 +1375,12 @@
                 "phar-io/version": "^1.0",
                 "php": "^7.0",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.2.2",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^4.0.3",
-                "sebastian/comparator": "^2.0.2",
+                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "sebastian/comparator": "^2.1",
                 "sebastian/diff": "^2.0",
                 "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
@@ -1399,7 +1406,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.4.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -1425,33 +1432,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-08T11:26:09+00:00"
+            "time": "2018-04-10T11:38:34+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.4",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0"
+                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/2f789b59ab89669015ad984afa350c4ec577ade0",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.5",
                 "php": "^7.0",
                 "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.0"
+                "sebastian/exporter": "^3.1"
             },
             "conflict": {
                 "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.5"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1459,7 +1466,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1474,7 +1481,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1484,7 +1491,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-08-03T14:08:16+00:00"
+            "time": "2018-01-06T05:45:45+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1533,21 +1540,21 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.0",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1174d9018191e93cb9d719edec01257fc05f8158"
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1174d9018191e93cb9d719edec01257fc05f8158",
-                "reference": "1174d9018191e93cb9d719edec01257fc05f8158",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "sebastian/diff": "^2.0",
+                "sebastian/diff": "^2.0 || ^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
@@ -1593,7 +1600,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-11-03T07:16:52+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -2087,16 +2094,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -2133,7 +2140,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-01-29T19:49:41+00:00"
         }
     ],
     "aliases": [],

--- a/src/makeandship/elasticsearch/acf-elasticsearch-plugin.php
+++ b/src/makeandship/elasticsearch/acf-elasticsearch-plugin.php
@@ -49,7 +49,7 @@ class AcfElasticsearchPlugin
         add_action('wp_ajax_clear_index', array(&$this, 'clear_index'));
 
         // posts
-        add_action('save_post', array(&$this, 'save_post'));
+        add_action('save_post', array(&$this, 'save_post'), 20, 1); // after acf fields save - 15
         add_action('delete_post', array(&$this, 'delete_post'));
         add_action('trash_post', array(&$this, 'delete_post'));
         add_action('transition_post_status', array(&$this, 'transition_post_status'), 10, 3);

--- a/src/makeandship/elasticsearch/constants.php
+++ b/src/makeandship/elasticsearch/constants.php
@@ -40,6 +40,7 @@ class Constants
     const OPTION_SLUGS_TO_EXCLUDE = 'acf_elasticsearch_slugs_to_exclude';
     const OPTION_EXCLUSION_FIELD = 'acf_elasticsearch_exclusion_field';
     const OPTION_IDS_TO_EXCLUDE = 'acf_elasticsearch_ids_to_exclude';
+    const OPTION_ELASTICSEARCH_VERSION = 'acf_elasticsearch_cluster_version';
 
     // indexer
     const STATUS_PUBLISH = 'publish';

--- a/src/makeandship/elasticsearch/constants.php
+++ b/src/makeandship/elasticsearch/constants.php
@@ -50,6 +50,7 @@ class Constants
     const DEFAULT_POSTS_PER_PAGE = 100;
     const DEFAULT_TERMS_PER_PAGE = 50;
     const DEFAULT_SITES_PER_PAGE = 50;
+    const DEFAULT_MAPPING_TYPE = 'document';
 
     // no instantiation
     protected function __construct()

--- a/src/makeandship/elasticsearch/document-builder.php
+++ b/src/makeandship/elasticsearch/document-builder.php
@@ -2,7 +2,6 @@
 
 namespace makeandship\elasticsearch;
 
-use \Elastica\Client;
 use makeandship\elasticsearch\settings\SettingsManager;
 
 abstract class DocumentBuilder
@@ -15,18 +14,18 @@ abstract class DocumentBuilder
     public function get_core_fields($type) {
         // read elasticsearch version
 		$version = $this->get_elasticseach_version();
-		$use_v6 = version_compare($version,  "6.0");
+		$use_v6 = version_compare($version,  "6.0") >= 0 ;
 		
-		if ($type == 'WP_Post' && $use_v6 >= 0) {
+		if ($type == 'WP_Post' && $use_v6) {
 			return PostMappingBuilderV6::CORE_FIELDS;
 		}
-		else if ($type == 'WP_Post' && $use_v6 < 0) {
+		else if ($type == 'WP_Post') {
 			return PostMappingBuilderV5::CORE_FIELDS;
 		}
-		else if ($type == 'WP_Term' && $use_v6 >= 0) {
+		else if ($type == 'WP_Term' && $use_v6) {
 			return TermMappingBuilderV6::CORE_FIELDS;
 		}
-		else if ($type == 'WP_Term' && $use_v6 < 0) {
+		else if ($type == 'WP_Term') {
 			return TermMappingBuilderV5::CORE_FIELDS;
 		}
 		else if ($type == 'WP_Site') {
@@ -38,8 +37,6 @@ abstract class DocumentBuilder
 
     private function get_elasticseach_version()
     {
-        $client_settings = SettingsManager::get_instance()->get_client_settings();
-        $client = new Client($client_settings);
-        return $client->getVersion();
+        return SettingsManager::get_instance()->get(Constants::OPTION_ELASTICSEARCH_VERSION);
     }
 }

--- a/src/makeandship/elasticsearch/document-builder.php
+++ b/src/makeandship/elasticsearch/document-builder.php
@@ -2,10 +2,44 @@
 
 namespace makeandship\elasticsearch;
 
+use \Elastica\Client;
+use makeandship\elasticsearch\settings\SettingsManager;
+
 abstract class DocumentBuilder
 {
     abstract public function build($o, $include_private=false);
     abstract public function is_private($o);
     abstract public function has_private_fields();
     abstract public function is_indexable($o);
+    
+    public function get_core_fields($type) {
+        // read elasticsearch version
+		$version = $this->get_elasticseach_version();
+		$use_v6 = version_compare($version,  "6.0");
+		
+		if ($type == 'WP_Post' && $use_v6 >= 0) {
+			return PostMappingBuilderV6::CORE_FIELDS;
+		}
+		else if ($type == 'WP_Post' && $use_v6 < 0) {
+			return PostMappingBuilderV5::CORE_FIELDS;
+		}
+		else if ($type == 'WP_Term' && $use_v6 >= 0) {
+			return TermMappingBuilderV6::CORE_FIELDS;
+		}
+		else if ($type == 'WP_Term' && $use_v6 < 0) {
+			return TermMappingBuilderV5::CORE_FIELDS;
+		}
+		else if ($type == 'WP_Site') {
+			return SiteMappingBuilder::CORE_FIELDS;
+		}
+
+		return array();
+    }
+
+    private function get_elasticseach_version()
+    {
+        $client_settings = SettingsManager::get_instance()->get_client_settings();
+        $client = new Client($client_settings);
+        return $client->getVersion();
+    }
 }

--- a/src/makeandship/elasticsearch/mapper.php
+++ b/src/makeandship/elasticsearch/mapper.php
@@ -20,30 +20,41 @@ class Mapper
     {
         // create mappings for each post type
         $post_types = $this->post_types = SettingsManager::get_instance()->get_post_types();
-        
+
+        // mapping builder
+        $post_mapping_builder = $this->mapping_builder_factory->create('WP_Post');
+        $term_mapping_builder = $this->mapping_builder_factory->create('WP_Term');
+        $site_mapping_builder = $this->mapping_builder_factory->create('WP_Site');
+
+        $properties = array();
+
         foreach ($post_types as $post_type) {
-            $this->map_type(
-                new PostMappingBuilder(),
-                $post_type
+            $properties = array_merge(
+                $properties,
+                $post_mapping_builder->build($post_type)
             );
         }
+
+        //error_log(json_encode($mapping));
 
         // create mappings for each taxonomy
         $taxonomies = get_taxonomies();
         foreach ($taxonomies as $taxonomy) {
-            $this->map_type(
-                new TermMappingBuilder(),
-                $taxonomy
-            );
+          $properties = array_merge(
+            $properties,
+            $term_mapping_builder->build($taxonomy)
+          );
         }
 
         // create mappings for sites if this is a multisite
         if (is_multisite()) {
-            $this->map_type(
-                new SiteMappingBuilder(),
-                'sites'
-            );
+          $properties = array_merge(
+            $properties,
+            $site_mapping_builder->build()
+          );
         }
+
+        $this->create_mapping($properties);
     }
 
     private function map_type($builder, $type_name=null)
@@ -80,6 +91,39 @@ class Mapper
                     $mapping_private_secondary->send();
                 }
             }
+        }
+    }
+
+    private function create_mapping($properties, $type_name=Constants::DEFAULT_MAPPING_TYPE)
+    {
+        if (isset($properties)) {
+            // create mappings for the public primary index if required
+            $primary_type = $this->type_factory->create($type_name, false, false, true);
+            if ($primary_type) {
+                $mapping_primary = new Mapping($primary_type, $properties);
+                $mapping_primary->send();
+            }
+
+            // create mappings for the private primary index if required
+            $private_primary_type = $this->type_factory->create($type_name, false, true, true);
+            if ($private_primary_type) {
+                $mapping_private_primary = new Mapping($private_primary_type, $properties);
+                $mapping_private_primary->send();
+            }
+
+            // create mappings for the public secondary index if required
+            $secondary_type = $this->type_factory->create($type_name, false, false, false);
+            if ($secondary_type) {
+                $mapping_secondary = new Mapping($secondary_type, $properties);
+                $mapping_secondary->send();
+            }
+
+            // create mappings for the private secondary index if required
+            $private_secondary_type = $this->type_factory->create($type_name, false, true, false);
+            if ($private_secondary_type) {
+                $mapping_private_secondary = new Mapping($private_secondary_type, $properties);
+                $mapping_private_secondary->send();
+            }    
         }
     }
 }

--- a/src/makeandship/elasticsearch/mapping-builder-factory.php
+++ b/src/makeandship/elasticsearch/mapping-builder-factory.php
@@ -10,18 +10,18 @@ class MappingBuilderFactory {
 	public static final function create( $type ) {
 		// read elasticsearch version
 		$version = self::get_elasticseach_version();
-		$use_v6 = version_compare($version,  "6.0");
+		$use_v6 = version_compare($version,  "6.0") >= 0 ;
 		
-		if ($type == 'WP_Post' && $use_v6 >= 0) {
+		if ($type == 'WP_Post' && $use_v6) {
 			return new PostMappingBuilderV6();
 		}
-		else if ($type == 'WP_Post' && $use_v6 < 0) {
+		else if ($type == 'WP_Post') {
 			return new PostMappingBuilderV5();
 		}
-		else if ($type == 'WP_Term' && $use_v6 >= 0) {
+		else if ($type == 'WP_Term' && $use_v6) {
 			return new TermMappingBuilderV6();
 		}
-		else if ($type == 'WP_Term' && $use_v6 < 0) {
+		else if ($type == 'WP_Term') {
 			return new TermMappingBuilderV5();
 		}
 		else if ($type == 'WP_Site') {
@@ -33,8 +33,6 @@ class MappingBuilderFactory {
 
 	private static function get_elasticseach_version()
     {
-        $client_settings = SettingsManager::get_instance()->get_client_settings();
-        $client = new Client($client_settings);
-        return $client->getVersion();
+        return SettingsManager::get_instance()->get(Constants::OPTION_ELASTICSEARCH_VERSION);
     }
 }

--- a/src/makeandship/elasticsearch/mapping-builder-factory.php
+++ b/src/makeandship/elasticsearch/mapping-builder-factory.php
@@ -2,19 +2,39 @@
 
 namespace makeandship\elasticsearch;
 
+use \Elastica\Client;
+use makeandship\elasticsearch\settings\SettingsManager;
+
 class MappingBuilderFactory {
 	
-	public static final function create( $o ) {
-		if (is_a( $o, 'WP_Post')) {
-			return new PostMappingBuilder();
+	public static final function create( $type ) {
+		// read elasticsearch version
+		$version = self::get_elasticseach_version();
+		$use_v6 = version_compare($version,  "6.0");
+		
+		if ($type == 'WP_Post' && $use_v6 >= 0) {
+			return new PostMappingBuilderV6();
 		}
-		else if (is_a( $o, 'WP_Term')) {
-			return new TermMappingBuilder();
+		else if ($type == 'WP_Post' && $use_v6 < 0) {
+			return new PostMappingBuilderV5();
 		}
-		else if (is_a( $o, 'WP_Site')) {
+		else if ($type == 'WP_Term' && $use_v6 >= 0) {
+			return new TermMappingBuilderV6();
+		}
+		else if ($type == 'WP_Term' && $use_v6 < 0) {
+			return new TermMappingBuilderV5();
+		}
+		else if ($type == 'WP_Site') {
 			return new SiteMappingBuilder();
 		}
 
 		return null;
 	}
+
+	private static function get_elasticseach_version()
+    {
+        $client_settings = SettingsManager::get_instance()->get_client_settings();
+        $client = new Client($client_settings);
+        return $client->getVersion();
+    }
 }

--- a/src/makeandship/elasticsearch/mapping-builder.php
+++ b/src/makeandship/elasticsearch/mapping-builder.php
@@ -3,5 +3,22 @@
 namespace makeandship\elasticsearch;
 
 abstract class MappingBuilder {
+	const EXCLUDE_TAXONOMIES = array(
+        'post_tag',
+        'post_format'
+	);
+
+	const EXCLUDE_POST_TYPES = array(
+        'revision',
+        'attachment',
+        'json_consumer',
+        'nav_menu',
+        'nav_menu_item',
+        'post_format',
+        'link_category',
+        'acf-field-group',
+        'acf-field'
+    );
+	
 	abstract function build( $o );
 }

--- a/src/makeandship/elasticsearch/post-document-builder.php
+++ b/src/makeandship/elasticsearch/post-document-builder.php
@@ -76,9 +76,10 @@ class PostDocumentBuilder extends DocumentBuilder
         $document = null;
 
         if (isset($post)) {
+            $post->type = $post->post_type;
             $document = array();
 
-            foreach (PostMappingBuilder::CORE_FIELDS as $name => $definition) {
+            foreach ($this->get_core_fields('WP_Post') as $name => $definition) {
                 if ($name === 'link') {
                     $link = get_permalink($post->ID);
                     $document['link'] = $link;
@@ -137,7 +138,7 @@ class PostDocumentBuilder extends DocumentBuilder
             // taxonomies
             $taxonomies = get_object_taxonomies($post_type, 'objects');
             foreach ($taxonomies as $name => $taxonomy) {
-                if (!in_array($name, PostMappingBuilder::EXCLUDE_TAXONOMIES)) {
+                if (!in_array($name, MappingBuilder::EXCLUDE_TAXONOMIES)) {
                     $document = array_merge(
                         $document,
                         $this->build_taxonomy($post, $name, $taxonomy)
@@ -310,6 +311,6 @@ class PostDocumentBuilder extends DocumentBuilder
      */
     public function get_type($post)
     {
-        return $post->post_type;
+        return Constants::DEFAULT_MAPPING_TYPE;
     }
 }

--- a/src/makeandship/elasticsearch/post-mapping-builder-v5.php
+++ b/src/makeandship/elasticsearch/post-mapping-builder-v5.php
@@ -37,8 +37,8 @@ class PostMappingBuilderV5 extends PostMappingBuilder
      */
     public function build($post_type)
     {
-        if (!$this->valid($post_type)) {
-            return null;
+        if (!PostMappingBuilder::valid($post_type)) {
+            return array();
         }
 
         $properties = array();

--- a/src/makeandship/elasticsearch/post-mapping-builder-v5.php
+++ b/src/makeandship/elasticsearch/post-mapping-builder-v5.php
@@ -2,7 +2,7 @@
 
 namespace makeandship\elasticsearch;
 
-class PostMappingBuilderV5 extends MappingBuilder
+class PostMappingBuilderV5 extends PostMappingBuilder
 {
     const CORE_FIELDS = array(
         'type' => array(
@@ -30,9 +30,6 @@ class PostMappingBuilderV5 extends MappingBuilder
             'type' => 'string',
             'index' => 'not_analyzed'
         )
-    );
-
-    const CORE_DATE_FIELDS = array(
     );
 
     /**
@@ -94,31 +91,6 @@ class PostMappingBuilderV5 extends MappingBuilder
         }
 
         return $properties;
-    }
-
-    public function valid($post_type)
-    {
-        if (in_array($post_type, MappingBuilder::EXCLUDE_POST_TYPES)) {
-            return false;
-        }
-        return true;
-    }
-
-    // TODO right place?
-    public function get_valid_post_types()
-    {
-        $post_types = get_post_types(array(
-            'public' => true
-        ));
-        
-        $valid_post_types = array();
-        foreach ($post_types as $post_type) {
-            if ($this->valid($post_type)) {
-                $valid_post_types[] = $post_type;
-            }
-        }
-
-        return $valid_post_types;
     }
 
     private function build_field($field, $options)

--- a/src/makeandship/elasticsearch/post-mapping-builder-v5.php
+++ b/src/makeandship/elasticsearch/post-mapping-builder-v5.php
@@ -2,7 +2,7 @@
 
 namespace makeandship\elasticsearch;
 
-class PostMappingBuilder extends MappingBuilder
+class PostMappingBuilderV5 extends MappingBuilder
 {
     const EXCLUDE_POST_TYPES = array(
         'revision',
@@ -60,7 +60,7 @@ class PostMappingBuilder extends MappingBuilder
         $properties = array();
 
         // base post fields
-        foreach (PostMappingBuilder::CORE_FIELDS as $field => $options) {
+        foreach (PostMappingBuilderV5::CORE_FIELDS as $field => $options) {
             if (isset($field) && isset($options)) {
                 $properties = array_merge(
                     $properties,

--- a/src/makeandship/elasticsearch/post-mapping-builder-v5.php
+++ b/src/makeandship/elasticsearch/post-mapping-builder-v5.php
@@ -4,24 +4,11 @@ namespace makeandship\elasticsearch;
 
 class PostMappingBuilderV5 extends MappingBuilder
 {
-    const EXCLUDE_POST_TYPES = array(
-        'revision',
-        'attachment',
-        'json_consumer',
-        'nav_menu',
-        'nav_menu_item',
-        'post_format',
-        'link_category',
-        'acf-field-group',
-        'acf-field'
-    );
-
-    const EXCLUDE_TAXONOMIES = array(
-        'post_tag',
-        'post_format'
-    );
-
     const CORE_FIELDS = array(
+        'type' => array(
+            'type' => 'string',
+            'index' => 'not_analyzed'
+        ),
         'post_content' => array(
             'type' => 'string',
             'suggest' => true,
@@ -98,7 +85,7 @@ class PostMappingBuilderV5 extends MappingBuilder
         // post taxonomies
         $taxonomies = get_object_taxonomies($post_type, 'objects');
         foreach ($taxonomies as $name => $taxonomy) {
-            if (!in_array($name, self::EXCLUDE_TAXONOMIES)) {
+            if (!in_array($name, MappingBuilder::EXCLUDE_TAXONOMIES)) {
                 $properties = array_merge(
                     $properties,
                     $this->build_taxonomy($name, $taxonomy)
@@ -111,7 +98,7 @@ class PostMappingBuilderV5 extends MappingBuilder
 
     public function valid($post_type)
     {
-        if (in_array($post_type, self::EXCLUDE_POST_TYPES)) {
+        if (in_array($post_type, MappingBuilder::EXCLUDE_POST_TYPES)) {
             return false;
         }
         return true;

--- a/src/makeandship/elasticsearch/post-mapping-builder-v6.php
+++ b/src/makeandship/elasticsearch/post-mapping-builder-v6.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace makeandship\elasticsearch;
+
+class PostMappingBuilderV6 extends MappingBuilder
+{
+    const EXCLUDE_POST_TYPES = array(
+        'revision',
+        'attachment',
+        'json_consumer',
+        'nav_menu',
+        'nav_menu_item',
+        'post_format',
+        'link_category',
+        'acf-field-group',
+        'acf-field'
+    );
+
+    const EXCLUDE_TAXONOMIES = array(
+        'post_tag',
+        'post_format'
+    );
+
+    const CORE_FIELDS = array(
+        'type' => array(
+            'type' => 'keyword',
+            'index' => true
+        ),
+        'post_content' => array(
+            'type' => 'text',
+            'suggest' => true,
+            'transformer' => 'makeandship\elasticsearch\transformer\HtmlFieldTransformer'
+        ),
+        'post_title' => array(
+            'type' => 'text',
+            'suggest' => true
+        ),
+        'post_type' => array(
+            'type' => 'keyword',
+            'index' => true
+        ),
+        'post_date' => array(
+            'type' => 'date',
+            'transformer' => 'makeandship\elasticsearch\transformer\DateFieldTransformer'
+        ),
+        'link' => array(
+            'type' => 'keyword',
+            'index' => true
+        )
+    );
+
+    const CORE_DATE_FIELDS = array(
+    );
+
+    /**
+     *
+     */
+    public function build($post_type)
+    {
+        if (!$this->valid($post_type)) {
+            return null;
+        }
+
+        $properties = array();
+
+        // base post fields
+        foreach (PostMappingBuilderV6::CORE_FIELDS as $field => $options) {
+            if (isset($field) && isset($options)) {
+                $properties = array_merge(
+                    $properties,
+                    $this->build_field($field, $options)
+                );
+            }
+        }
+
+        // acf fields
+        if (class_exists('acf')) {
+            // field groups for this post type
+            $args = array(
+                'post_type' => $post_type
+            );
+            $field_groups = acf_get_field_groups($args);
+
+            if (isset($field_groups) && !empty($field_groups)) {
+                foreach ($field_groups as $field_group) {
+                    $field_group_id = $field_group['ID'];
+                    if ($field_group_id) {
+                        $fields = acf_get_fields($field_group_id);
+
+                        foreach ($fields as $field) {
+                            $field_properties = $this->build_acf_field($field);
+                            $properties = array_merge(
+                                $properties,
+                                $field_properties
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        // post taxonomies
+        $taxonomies = get_object_taxonomies($post_type, 'objects');
+        foreach ($taxonomies as $name => $taxonomy) {
+            if (!in_array($name, self::EXCLUDE_TAXONOMIES)) {
+                $properties = array_merge(
+                    $properties,
+                    $this->build_taxonomy($name, $taxonomy)
+                );
+            }
+        }
+
+        return $properties;
+    }
+
+    public function valid($post_type)
+    {
+        if (in_array($post_type, self::EXCLUDE_POST_TYPES)) {
+            return false;
+        }
+        return true;
+    }
+
+    // TODO right place?
+    public function get_valid_post_types()
+    {
+        $post_types = get_post_types(array(
+            'public' => true
+        ));
+        
+        $valid_post_types = array();
+        foreach ($post_types as $post_type) {
+            if ($this->valid($post_type)) {
+                $valid_post_types[] = $post_type;
+            }
+        }
+
+        return $valid_post_types;
+    }
+
+    private function build_field($field, $options)
+    {
+        $properties = array();
+
+        if (isset($field) && isset($options)) {
+            // settings
+            if (is_string($options)) {
+                $type = $options;
+                $index = true;
+                $suggest = null;
+            } else {
+                if (array_key_exists('type', $options)) {
+                    $type = $options['type'];
+                }
+                if (array_key_exists('index', $options)) {
+                    $index = $options['index'];
+                } else {
+                    $index = true;
+                }
+                if (array_key_exists('suggest', $options)) {
+                    $suggest = $options['suggest'];
+                }
+            }
+
+            $properties[$field] = array(
+                'type' => $type,
+                'index' => $index
+            );
+
+            if (isset($suggest)) {
+                $properties[$field.'_suggest'] = array(
+                    'type' => 'text',
+                    'analyzer' => 'ngram_analyzer',
+                    'search_analyzer' => 'whitespace_analyzer',
+                );
+            }
+        }
+
+        return $properties;
+    }
+
+    private function build_acf_field($field)
+    {
+        $properties = array();
+
+        if (isset($field)) {
+            if (array_key_exists('type', $field) && array_key_exists('name', $field) && $field['type'] != 'tab') {
+                $acf_type = $field['type'];
+                $name = $field['name'];
+
+                // default to index each field
+                $props = array(
+                    'type' => 'text',
+                    'index' => true
+                );
+                
+                // default to text
+                // color_picker, email, page_link, radio, select, text, textarea, url, wysiwyg
+
+                switch ($acf_type) {
+                    case 'checkbox':
+                        $props['type'] = 'boolean';
+                        $props['index'] = true;
+                        break;
+                    case 'date_picker':
+                        $props['type'] = 'date';
+                        $props['index'] = true;
+                        break;
+
+                    case 'date_time_picker':
+                        $props['type'] = 'date';
+                        $props['index'] = true;
+                        break;
+
+                    case 'file':
+                        break;
+
+                    case 'google_map':
+                        $props['type'] = 'geo_point';
+                        $props['index'] = true;
+                        break;
+
+                    case 'image':
+                        // nested
+                        break;
+
+                    case 'message':
+                        break;
+
+                    case 'number':
+                        $props['type'] = 'long';
+                        $props['index'] = true;
+                        break;
+
+                    case 'oembed':
+                        // nested
+                        break;
+
+                    case 'password':
+                        // dont index
+                        break;
+
+                    case 'post_object':
+                        // id?
+                        break;
+
+                    case 'relationship':
+                        // alter name to identify where further processing is required on lookup
+                        $name = $name.'_relationship';
+                        $props['type'] = 'long';
+                        $props['index'] = true;
+                        break;
+
+                    case 'repeater':
+                        $props['type'] = 'nested';
+                        $props['properties'] = array();
+                        unset($props['index']);
+
+                        foreach ($field['sub_fields'] as $sub_field) {
+                            $sub_field_name = $sub_field['name'];
+                            $sub_field_props = $this->build_acf_field($sub_field);
+
+                            if (isset($sub_field_props) && !empty($sub_field_props)) {
+                                $props['properties'] = array_merge(
+                                    $props['properties'],
+                                    $sub_field_props
+                                );
+                            }
+                        }
+                        break;
+
+                    case 'taxonomy':
+                        break;
+
+                    case 'time_picker':
+                        $props['type'] = 'date';
+                        $props['index'] = true;
+                        $props['format'] = 'HH:mm:ss';
+                        break;
+
+                    case 'true_false':
+                        $props['type'] = 'boolean';
+                        $props['index'] = true;
+                        break;
+
+                    case 'user':
+                        // custom
+                        break;
+  
+                }
+
+                if (isset($props) && isset($name)) {
+                    $properties[$name] = $props;
+                }
+            }
+        }
+
+        return $properties;
+    }
+    
+    private function build_taxonomy($name, $taxonomy)
+    {
+        $properties = array();
+
+        if (isset($name)) {
+            $properties[$name] = array(
+                "index" => true,
+                "type" => "keyword"
+            );
+            
+            $properties[$name.'_name'] = array(
+                "type" => "text"
+            );
+
+            $properties[$name.'_suggest'] = array(
+                "analyzer" => "ngram_analyzer",
+                "search_analyzer" => "whitespace_analyzer",
+                "type" => "text"
+            );
+        }
+    
+        return $properties;
+    }
+}

--- a/src/makeandship/elasticsearch/post-mapping-builder-v6.php
+++ b/src/makeandship/elasticsearch/post-mapping-builder-v6.php
@@ -2,7 +2,7 @@
 
 namespace makeandship\elasticsearch;
 
-class PostMappingBuilderV6 extends MappingBuilder
+class PostMappingBuilderV6 extends PostMappingBuilder
 {
     const CORE_FIELDS = array(
         'type' => array(
@@ -30,9 +30,6 @@ class PostMappingBuilderV6 extends MappingBuilder
             'type' => 'keyword',
             'index' => true
         )
-    );
-
-    const CORE_DATE_FIELDS = array(
     );
 
     /**
@@ -85,7 +82,7 @@ class PostMappingBuilderV6 extends MappingBuilder
         // post taxonomies
         $taxonomies = get_object_taxonomies($post_type, 'objects');
         foreach ($taxonomies as $name => $taxonomy) {
-            if (!in_array($name, MappingBuilder::EXCLUDE_TAXONOMIES)) {
+            if (!in_array($name, PostMappingBuilder::EXCLUDE_TAXONOMIES)) {
                 $properties = array_merge(
                     $properties,
                     $this->build_taxonomy($name, $taxonomy)
@@ -94,31 +91,6 @@ class PostMappingBuilderV6 extends MappingBuilder
         }
 
         return $properties;
-    }
-
-    public function valid($post_type)
-    {
-        if (in_array($post_type, MappingBuilder::EXCLUDE_POST_TYPES)) {
-            return false;
-        }
-        return true;
-    }
-
-    // TODO right place?
-    public function get_valid_post_types()
-    {
-        $post_types = get_post_types(array(
-            'public' => true
-        ));
-        
-        $valid_post_types = array();
-        foreach ($post_types as $post_type) {
-            if ($this->valid($post_type)) {
-                $valid_post_types[] = $post_type;
-            }
-        }
-
-        return $valid_post_types;
     }
 
     private function build_field($field, $options)

--- a/src/makeandship/elasticsearch/post-mapping-builder-v6.php
+++ b/src/makeandship/elasticsearch/post-mapping-builder-v6.php
@@ -4,23 +4,6 @@ namespace makeandship\elasticsearch;
 
 class PostMappingBuilderV6 extends MappingBuilder
 {
-    const EXCLUDE_POST_TYPES = array(
-        'revision',
-        'attachment',
-        'json_consumer',
-        'nav_menu',
-        'nav_menu_item',
-        'post_format',
-        'link_category',
-        'acf-field-group',
-        'acf-field'
-    );
-
-    const EXCLUDE_TAXONOMIES = array(
-        'post_tag',
-        'post_format'
-    );
-
     const CORE_FIELDS = array(
         'type' => array(
             'type' => 'keyword',
@@ -102,7 +85,7 @@ class PostMappingBuilderV6 extends MappingBuilder
         // post taxonomies
         $taxonomies = get_object_taxonomies($post_type, 'objects');
         foreach ($taxonomies as $name => $taxonomy) {
-            if (!in_array($name, self::EXCLUDE_TAXONOMIES)) {
+            if (!in_array($name, MappingBuilder::EXCLUDE_TAXONOMIES)) {
                 $properties = array_merge(
                     $properties,
                     $this->build_taxonomy($name, $taxonomy)
@@ -115,7 +98,7 @@ class PostMappingBuilderV6 extends MappingBuilder
 
     public function valid($post_type)
     {
-        if (in_array($post_type, self::EXCLUDE_POST_TYPES)) {
+        if (in_array($post_type, MappingBuilder::EXCLUDE_POST_TYPES)) {
             return false;
         }
         return true;

--- a/src/makeandship/elasticsearch/post-mapping-builder-v6.php
+++ b/src/makeandship/elasticsearch/post-mapping-builder-v6.php
@@ -37,8 +37,8 @@ class PostMappingBuilderV6 extends PostMappingBuilder
      */
     public function build($post_type)
     {
-        if (!$this->valid($post_type)) {
-            return null;
+        if (!PostMappingBuilder::valid($post_type)) {
+            return array();
         }
 
         $properties = array();

--- a/src/makeandship/elasticsearch/post-mapping-builder.php
+++ b/src/makeandship/elasticsearch/post-mapping-builder.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace makeandship\elasticsearch;
+
+abstract class PostMappingBuilder extends MappingBuilder
+{
+
+const EXCLUDE_TAXONOMIES = array(
+  'post_tag',
+  'post_format'
+);
+
+const EXCLUDE_POST_TYPES = array(
+  'revision',
+  'attachment',
+  'json_consumer',
+  'nav_menu',
+  'nav_menu_item',
+  'post_format',
+  'link_category',
+  'acf-field-group',
+  'acf-field'
+);
+
+const CORE_DATE_FIELDS = array(
+);
+
+private static function valid($post_type)
+{
+    if (in_array($post_type, PostMappingBuilder::EXCLUDE_POST_TYPES)) {
+        return false;
+    }
+    return true;
+}
+
+// TODO right place?
+public static function get_valid_post_types()
+{
+    $post_types = get_post_types(array(
+        'public' => true
+    ));
+    
+    $valid_post_types = array();
+    foreach ($post_types as $post_type) {
+        if (self::valid($post_type)) {
+            $valid_post_types[] = $post_type;
+        }
+    }
+
+    return $valid_post_types;
+}
+
+}

--- a/src/makeandship/elasticsearch/post-mapping-builder.php
+++ b/src/makeandship/elasticsearch/post-mapping-builder.php
@@ -25,7 +25,7 @@ const EXCLUDE_POST_TYPES = array(
 const CORE_DATE_FIELDS = array(
 );
 
-private static function valid($post_type)
+public static function valid($post_type)
 {
     if (in_array($post_type, PostMappingBuilder::EXCLUDE_POST_TYPES)) {
         return false;

--- a/src/makeandship/elasticsearch/queries/query-builder.php
+++ b/src/makeandship/elasticsearch/queries/query-builder.php
@@ -304,8 +304,8 @@ class QueryBuilder
                 // post type is used for the index type and therefore uses a type query
                 // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html
                 $query_taxonomy_filters['filter']['bool']['should'][] = array(
-                    'type' => array(
-                        'value' => $post_type
+                    'term' => array(
+                        'type' => $post_type
                     )
                 );
             }
@@ -328,8 +328,8 @@ class QueryBuilder
                 // post type is used for the index type and therefore uses a type query
                 // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html
                 $query_taxonomy_filters['filter']['bool']['should'][] = array(
-                    'type' => array(
-                        'value' => $taxonomy
+                    'term' => array(
+                        'type' => $taxonomy
                     )
                 );
             }

--- a/src/makeandship/elasticsearch/queries/query-builder.php
+++ b/src/makeandship/elasticsearch/queries/query-builder.php
@@ -12,8 +12,7 @@ class QueryBuilder
     public function __construct()
     {
         // default include all valid post types
-        $post_mapping_builder = new PostMappingBuilder();
-        $this->post_types = $post_mapping_builder->get_valid_post_types();
+        $this->post_types = PostMappingBuilder::get_valid_post_types();
 
         $this->freetext = null;
         $this->fuzziness = null;

--- a/src/makeandship/elasticsearch/settings/settings-manager.php
+++ b/src/makeandship/elasticsearch/settings/settings-manager.php
@@ -4,6 +4,7 @@ namespace makeandship\elasticsearch\settings;
 
 use makeandship\elasticsearch\Constants;
 use makeandship\elasticsearch\Util;
+use \Elastica\Client;
 
 class SettingsManager
 {
@@ -62,6 +63,7 @@ class SettingsManager
             $this->settings[Constants::OPTION_SLUGS_TO_EXCLUDE] = $this->get_option(Constants::OPTION_SLUGS_TO_EXCLUDE);
             $this->settings[Constants::OPTION_EXCLUSION_FIELD] = $this->get_option(Constants::OPTION_EXCLUSION_FIELD);
             $this->settings[Constants::OPTION_IDS_TO_EXCLUDE] = $this->get_option(Constants::OPTION_IDS_TO_EXCLUDE);
+            $this->settings[Constants::OPTION_ELASTICSEARCH_VERSION] = $this->get_elasticseach_version();
         }
         
         return $this->settings;
@@ -106,7 +108,8 @@ class SettingsManager
                 Constants::OPTION_FUZZINESS,
                 Constants::OPTION_SLUGS_TO_EXCLUDE,
                 Constants::OPTION_EXCLUSION_FIELD,
-                Constants::OPTION_IDS_TO_EXCLUDE
+                Constants::OPTION_IDS_TO_EXCLUDE,
+                Constants::OPTION_ELASTICSEARCH_VERSION
             ])) {
                 return true;
             }
@@ -261,5 +264,12 @@ class SettingsManager
         }
 
         return $types;
+    }
+
+    private function get_elasticseach_version()
+    {
+        $client_settings = $this->get_client_settings();
+        $client = new Client($client_settings);
+        return $client->getVersion();
     }
 }

--- a/src/makeandship/elasticsearch/site-mapping-builder.php
+++ b/src/makeandship/elasticsearch/site-mapping-builder.php
@@ -13,7 +13,7 @@ class SiteMappingBuilder extends MappingBuilder {
 	/**
 	 *
 	 */
-	public function build ( $name ) {
+	public function build ( $name = null ) {
 		$properties = array();
 
 		// base post fields

--- a/src/makeandship/elasticsearch/term-document-builder.php
+++ b/src/makeandship/elasticsearch/term-document-builder.php
@@ -36,7 +36,8 @@ class TermDocumentBuilder extends DocumentBuilder
         $document = null;
 
         if (isset($term)) {
-            foreach (TermMappingBuilder::CORE_FIELDS as $name => $definition) {
+            $term->type = $term->taxonomy;
+            foreach ($this->get_core_fields('WP_Term') as $name => $definition) {
                 $value = $term->{$name};
 
                 // transform if required
@@ -74,6 +75,6 @@ class TermDocumentBuilder extends DocumentBuilder
      */
     public function get_type($term)
     {
-        return $term->taxonomy;
+        return Constants::DEFAULT_MAPPING_TYPE;
     }
 }

--- a/src/makeandship/elasticsearch/term-mapping-builder-v5.php
+++ b/src/makeandship/elasticsearch/term-mapping-builder-v5.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace makeandship\elasticsearch;
+
+class TermMappingBuilderV5 extends MappingBuilder {
+
+	const EXCLUDE_TAXONOMIES = array(
+		'nav_menu',
+		'post_format',
+		'link_category',
+	);
+
+	const CORE_FIELDS = array(
+		'name' => array(
+			'type' => 'string', 
+			'suggest' => true
+		),
+		'slug' => array(
+			'type' => 'string',
+			'index' => 'not_analyzed'
+		),
+	);
+
+	/**
+	 *
+	 */
+	public function build ( $taxonomy ) {
+		$properties = array();
+		
+		if (!$this->valid( $taxonomy )) {
+			return null;
+		}
+
+		// TODO implement (this is post)
+
+		// base post fields
+		foreach( TermMappingBuilderV5::CORE_FIELDS as $field => $options) {
+			if (isset( $field ) && isset($options)) {
+				$properties = array_merge( 
+					$properties, 
+					$this->build_field( $field, $options ) 
+				);	
+			}
+		}
+
+		return $properties;
+	}
+
+	public function valid( $taxonomy ) {
+		if (in_array( $taxonomy, self::EXCLUDE_TAXONOMIES)) {
+			return false;
+		}
+		return true;
+	}
+
+	function build_field( $field, $options) {
+		$properties = array();
+
+		if (isset( $field ) && isset( $options )) {
+			$properties = array( 
+				'name_suggest' => array(
+					'analyzer' => 'ngram_analyzer',
+					'search_analyzer' => 'whitespace_analyzer',
+					'type' => 'string'
+				),
+				'name' => array(
+					'type' => 'string'
+				),
+				'slug' => array( 
+					'type' => 'string',
+					'index' => 'not_analyzed'
+					)
+			);
+		}
+
+		return $properties;
+	}
+}

--- a/src/makeandship/elasticsearch/term-mapping-builder-v5.php
+++ b/src/makeandship/elasticsearch/term-mapping-builder-v5.php
@@ -26,7 +26,7 @@ class TermMappingBuilderV5 extends TermMappingBuilder {
 		$properties = array();
 		
 		if (!$this->valid( $taxonomy )) {
-			return null;
+			return array();
 		}
 
 		// TODO implement (this is post)

--- a/src/makeandship/elasticsearch/term-mapping-builder-v5.php
+++ b/src/makeandship/elasticsearch/term-mapping-builder-v5.php
@@ -11,6 +11,10 @@ class TermMappingBuilderV5 extends MappingBuilder {
 	);
 
 	const CORE_FIELDS = array(
+		'type' => array(
+            'type' => 'string',
+            'index' => 'not_analyzed'
+        ),
 		'name' => array(
 			'type' => 'string', 
 			'suggest' => true

--- a/src/makeandship/elasticsearch/term-mapping-builder-v5.php
+++ b/src/makeandship/elasticsearch/term-mapping-builder-v5.php
@@ -2,13 +2,7 @@
 
 namespace makeandship\elasticsearch;
 
-class TermMappingBuilderV5 extends MappingBuilder {
-
-	const EXCLUDE_TAXONOMIES = array(
-		'nav_menu',
-		'post_format',
-		'link_category',
-	);
+class TermMappingBuilderV5 extends TermMappingBuilder {
 
 	const CORE_FIELDS = array(
 		'type' => array(
@@ -48,13 +42,6 @@ class TermMappingBuilderV5 extends MappingBuilder {
 		}
 
 		return $properties;
-	}
-
-	public function valid( $taxonomy ) {
-		if (in_array( $taxonomy, self::EXCLUDE_TAXONOMIES)) {
-			return false;
-		}
-		return true;
 	}
 
 	function build_field( $field, $options) {

--- a/src/makeandship/elasticsearch/term-mapping-builder-v6.php
+++ b/src/makeandship/elasticsearch/term-mapping-builder-v6.php
@@ -2,13 +2,7 @@
 
 namespace makeandship\elasticsearch;
 
-class TermMappingBuilderV6 extends MappingBuilder {
-
-	const EXCLUDE_TAXONOMIES = array(
-		'nav_menu',
-		'post_format',
-		'link_category',
-	);
+class TermMappingBuilderV6 extends TermMappingBuilder {
 
 	const CORE_FIELDS = array(
 		'type' => array(
@@ -48,13 +42,6 @@ class TermMappingBuilderV6 extends MappingBuilder {
 		}
 
 		return $properties;
-	}
-
-	public function valid( $taxonomy ) {
-		if (in_array( $taxonomy, self::EXCLUDE_TAXONOMIES)) {
-			return false;
-		}
-		return true;
 	}
 
 	function build_field( $field, $options) {

--- a/src/makeandship/elasticsearch/term-mapping-builder-v6.php
+++ b/src/makeandship/elasticsearch/term-mapping-builder-v6.php
@@ -2,7 +2,7 @@
 
 namespace makeandship\elasticsearch;
 
-class TermMappingBuilder extends MappingBuilder {
+class TermMappingBuilderV6 extends MappingBuilder {
 
 	const EXCLUDE_TAXONOMIES = array(
 		'nav_menu',
@@ -11,13 +11,17 @@ class TermMappingBuilder extends MappingBuilder {
 	);
 
 	const CORE_FIELDS = array(
+		'type' => array(
+            'type' => 'keyword',
+            'index' => true
+        ),
 		'name' => array(
-			'type' => 'string', 
+			'type' => 'text', 
 			'suggest' => true
 		),
 		'slug' => array(
-			'type' => 'string',
-			'index' => 'not_analyzed'
+			'type' => 'keyword',
+			'index' => true
 		),
 	);
 
@@ -28,13 +32,13 @@ class TermMappingBuilder extends MappingBuilder {
 		$properties = array();
 		
 		if (!$this->valid( $taxonomy )) {
-			return null;
+			return array();
 		}
 
 		// TODO implement (this is post)
 
 		// base post fields
-		foreach( TermMappingBuilder::CORE_FIELDS as $field => $options) {
+		foreach( TermMappingBuilderV6::CORE_FIELDS as $field => $options) {
 			if (isset( $field ) && isset($options)) {
 				$properties = array_merge( 
 					$properties, 
@@ -61,15 +65,15 @@ class TermMappingBuilder extends MappingBuilder {
 				'name_suggest' => array(
 					'analyzer' => 'ngram_analyzer',
 					'search_analyzer' => 'whitespace_analyzer',
-					'type' => 'string'
+					'type' => 'text'
 				),
 				'name' => array(
-					'type' => 'string'
+					'type' => 'text'
 				),
 				'slug' => array( 
-					'type' => 'string',
-					'index' => 'not_analyzed'
-					)
+					'type' => 'keyword',
+					'index' => true
+				)
 			);
 		}
 

--- a/src/makeandship/elasticsearch/term-mapping-builder.php
+++ b/src/makeandship/elasticsearch/term-mapping-builder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace makeandship\elasticsearch;
+
+abstract class TermMappingBuilder extends MappingBuilder
+{
+
+    const EXCLUDE_TAXONOMIES = array(
+		'nav_menu',
+		'post_format',
+		'link_category',
+    );
+    
+	public function valid( $taxonomy ) {
+		if (in_array( $taxonomy, TermMappingBuilder::EXCLUDE_TAXONOMIES)) {
+			return false;
+		}
+		return true;
+	}
+
+}

--- a/tests/makeandship/elasticsearch/query-builder-test.php
+++ b/tests/makeandship/elasticsearch/query-builder-test.php
@@ -66,11 +66,11 @@ class QueryBuilderTest extends WP_UnitTestCase
             ->returning(array('name', 'title'))
             ->with_fuzziness(1)
             ->to_array();
-
+        
         $this->assertEquals($query['query']['bool']['must']['multi_match']['query'], 'Ace');
         $this->assertEquals($query['query']['bool']['must']['multi_match']['fuzziness'], 1);
         $this->assertEquals($query['query']['bool']['must']['multi_match']['fields'][0], 'name');
-        $this->assertEquals($query['query']['bool']['filter']['bool']['should'][0]['type']['value'], 'article');
+        $this->assertEquals($query['query']['bool']['filter']['bool']['should'][0]['term']['type'], 'article');
         $this->assertEquals($query['aggs']['post_type']['aggs']['facet']['terms']['field'], 'post_type');
         $this->assertEquals($query['aggs']['post_type']['aggs']['facet']['terms']['size'], 1);
         $this->assertEquals($query['from'], 0);

--- a/tests/makeandship/elasticsearch/searcher-test.php
+++ b/tests/makeandship/elasticsearch/searcher-test.php
@@ -4,6 +4,7 @@ require_once(__DIR__ . '/../../../acf-elasticsearch-autoloader.php');
 
 use makeandship\elasticsearch\Searcher;
 use makeandship\elasticsearch\Constants;
+use makeandship\elasticsearch\queries\QueryBuilder;
 use makeandship\elasticsearch\AcfElasticsearchPlugin;
 
 class SearcherTest extends WP_UnitTestCase
@@ -17,7 +18,12 @@ class SearcherTest extends WP_UnitTestCase
             ) 
         );
         $searcher = new Searcher();
-        $result = $searcher->search('for');
+        $query = new QueryBuilder();
+        $query = $query->freetext("Just")
+            ->with_fuzziness()
+            ->weighted();
+
+        $result = $searcher->search($query->to_array());
 
         $this->assertNotNull($result);
     }


### PR DESCRIPTION
Hi mate,
Could you please review this PR.
Here is the approach implemented:
1- Read the elasticsearch version from the cluster and save it to the settings singleton.
2- Create a default mapping type document.
3- If the elasticsearch version is 6.0 or greater use the PostMappingBuilderV6 otherwise use PostMappingBuilderV5
4- All the mapping is created under one type.
5- Index a field called type, this will hold the post type or term taxonomy
6- Adjust the search and suggestion queries
7- Add unit tests
Thanks.