### PR TITLE
Term handlers

### DIFF
--- a/acf-elasticsearch.php
+++ b/acf-elasticsearch.php
@@ -3,7 +3,7 @@
 Plugin Name: ACF Elasticsearch
 Plugin URI:  https://www/makeandship.com/blog/acf-elasticsearch
 Description: Elasticsearch integration for ACF-based wordpress sites
-Version:     7.1.8
+Version:     7.2.0
 Author:      Make and Ship Limited
 Author URI:  https://www.makeandship.com/
 License:     MIT

--- a/src/makeandship/elasticsearch/constants.php
+++ b/src/makeandship/elasticsearch/constants.php
@@ -18,7 +18,7 @@ class Constants
     const DEFAULT_READ_TIMEOUT  = 30;
 
     // plugin
-    const VERSION    = '7.1.8';
+    const VERSION    = '7.2.0';
     const DB_VERSION = 1;
 
     const OPTION_SERVER                  = 'acf_elasticsearch_server';

--- a/src/makeandship/elasticsearch/domain/posts-manager.php
+++ b/src/makeandship/elasticsearch/domain/posts-manager.php
@@ -109,6 +109,22 @@ class PostsManager
         return $posts;
     }
 
+    function get_posts_by_term($blog_id, $term_id, $taxonomy)
+    {
+        if (isset($blog_id)) {
+            switch_to_blog($blog_id);
+        }
+
+        $args  = $this->get_post_args_by_term($term_id, $taxonomy);
+        $posts = get_posts($args);
+
+        if (isset($blog_id)) {
+            restore_current_blog();
+        }
+
+        return $posts;
+    }
+
     function get_count_post_args()
     {
         $post_types     = $this->get_valid_post_types();
@@ -139,6 +155,36 @@ class PostsManager
             'paged'          => $page,
             'orderby'        => array(
                 'ID' => 'ASC',
+            ),
+        );
+
+        return $args;
+    }
+
+    function get_post_args_by_term($term_id, $taxonomy)
+    {
+        $post_types     = $this->get_valid_post_types();
+        $post_status    = array('publish', 'private');
+        $ids_to_exclude = SettingsManager::get_instance()->get(Constants::OPTION_IDS_TO_EXCLUDE);
+
+        if (!is_array($term_id)) {
+            $term_id = [$term_id];
+        }
+
+        $args = array(
+            'post_type'   => $post_types,
+            'post_status' => $post_status,
+            'exclude'     => $ids_to_exclude,
+            'numberposts' => -1,
+            'orderby'     => array(
+                'ID' => 'ASC',
+            ),
+            'tax_query'   => array(
+                array(
+                    'taxonomy' => $taxonomy,
+                    'field'    => 'term_id',
+                    'terms'    => $term_id,
+                ),
             ),
         );
 

--- a/src/makeandship/elasticsearch/indexer.php
+++ b/src/makeandship/elasticsearch/indexer.php
@@ -341,6 +341,32 @@ class Indexer
     }
 
     /**
+     * Add a set of wordpress objects for a given term and taxonomy
+     *
+     * @param $term_id a term_id or array of term_ids that have changed
+     * @param $taxonomy of the changed term
+     */
+    public function add_or_update_documents_by_term($term_id, $taxonomy)
+    {
+        $count = 0;
+
+        if ($term_id && $taxonomy) {
+            $posts_manager = new PostsManager();
+            $posts         = $posts_manager->get_posts_by_term(null, $term_id, $taxonomy);
+
+            if ($posts && is_array($posts) && count($posts) > 0) {
+                foreach ($posts as $item) {
+                    $this->add_or_update_document($item);
+
+                    $count++;
+                }
+            }
+        }
+
+        return $count;
+    }
+
+    /**
      * Add a wordpress object to an index
      *
      * Supported objects are


### PR DESCRIPTION
Re-index posts when term details change, specifically:

* Re-index all posts that were assigned to a deleted term to delete the term
* Re-index all posts that are assigned to an edited term